### PR TITLE
added inputs and a 'run' button to shinny app

### DIFF
--- a/R/availableGScores.R
+++ b/R/availableGScores.R
@@ -58,6 +58,7 @@ availableGScores <- function(installed=FALSE, ah.only=FALSE) {
     orggrp <- sapply(res$Name[res$Installed],
                      function(pkg) {
                        obj <- getFromNamespace(pkg, pkg)
+                       unloadNamespace(pkg)
                        c(organism(obj), gscoresCategory(obj))
                      })
     res[res$Installed, c("Organism", "Category")] <- t(orggrp)

--- a/inst/shinyApp/.Rhistory
+++ b/inst/shinyApp/.Rhistory
@@ -1,0 +1,1 @@
+remove.packages("GenomicScores", lib="~/R/x86_64-pc-linux-gnu-library/4.0")

--- a/inst/shinyApp/global.R
+++ b/inst/shinyApp/global.R
@@ -97,8 +97,7 @@ is_within_range <- function(name, rStart, rEnd, phast){
 
 # Checks with a name string if a package is loaded or attached
 .isPkgLoaded <- function(name) {
-  (paste("package:", name, sep="") %in% search()) ||
-    (name %in% loadedNamespaces())
+  paste("package:", name, sep="") %in% search()
 }
 
 

--- a/inst/shinyApp/global.R
+++ b/inst/shinyApp/global.R
@@ -3,16 +3,6 @@ options(htmlwidgets.TOJSON_ARGS = list(na = 'string'))
 
 ##### General functions #######
 
-# Returns GScore packages installed in user's machine
-avAnnotations <- function(){
-  pp <- system.file("scripts", package="GenomicScores")
-  mkdatafnames <- list.files(pp, pattern="make-data_*")
-  gspkgnames <- sub("make-data_", "", mkdatafnames, fixed=TRUE)
-  gspkgnames <- sub(".R", "", gspkgnames, fixed=TRUE)
-  ip <- installed.packages()
-  gspkgnames[gspkgnames %in% ip]
-}
-
 
 ## imports BED files uploaded by the user through
 ## the shiny app. it only reads the first three
@@ -133,12 +123,11 @@ is_within_range <- function(name, rStart, rEnd, phast){
     tryCatch({
       annotObj <- get(pkgName)
     }, error=function(err) {
-      stop(sprintf("The annotation package %s should automatically load
-an %s object with the same name as the package.", pkgName, pkgType))
+      stop(sprintf("The annotation package %s should automatically load an %s object with the same name as the package.",
+                   pkgName, pkgType))
     })
   } else if (class(pkgName) != pkgType)
-    stop(sprintf("'%s' is not the name of an '%s' annotation package or
-an '%s' annotation object itself.",
+    stop(sprintf("'%s' is not the name of an '%s' annotation package or an '%s' annotation object itself.",
                  pkgName, pkgType, pkgType))
   else
     annotObj <- pkgName

--- a/inst/shinyApp/ui.R
+++ b/inst/shinyApp/ui.R
@@ -11,14 +11,19 @@ ui <- fluidPage(
     sidebarLayout(
         
         sidebarPanel(
-            selectInput("annotPackage", "Select a GScores object",
-                        choices = c("Choose an installed annotation package" = "", 
-                                    avAnnotations())),
+            selectInput("organism", "Select an Organism",
+                        choices = c("All" = "All", unique(availableGScores(installed=TRUE)$Organism)),
+                        selected = "All"),
+            selectInput("category", "Select a Category",
+                        choices = c("All" = "All", unique(availableGScores(installed=TRUE)$Category)),
+                        selected = "All"),
+            uiOutput("apkg"), 
             uiOutput("pop"),
             radioButtons("webOrBed", "Input genomic coordinates",
                          choices = list("Manually" = "web", "Uploading BED file" = "bed")),
             uiOutput("webOptions"),
             fileInput("upload", "Upload your Bed format file"),
+            actionButton("run", "Run"),
             width = 3
             
         ),
@@ -34,12 +39,8 @@ ui <- fluidPage(
                                                  verbatimTextOutput("citation")
                                           )
                                  ),
-                                 shinycustomloader::withLoader(DT::dataTableOutput("printGsWeb")),
-                                 downloadButton("dwn_web_bed", "Download BED"),
-                                 downloadButton("dwn_web_csv", "Download CSV"),
-                                 shinycustomloader::withLoader(DT::dataTableOutput("printGsBed")),
-                                 downloadButton("dwn_bed_bed", "Download BED"),
-                                 downloadButton("dwn_bed_csv", "Download CSV")
+                                 shinycustomloader::withLoader(DT::dataTableOutput("printGs")),
+                                 uiOutput("down_btn")
                                  ),
                         tabPanel("About",
                                  includeMarkdown("about.md")),

--- a/inst/shinyApp/www/style.css
+++ b/inst/shinyApp/www/style.css
@@ -3,3 +3,9 @@
 	font-weight: bold;
 	color: green;
       }
+
+.shiny-output-error {
+	font-size: 16px;
+	font-weight: bold;
+	color: green;
+      }


### PR DESCRIPTION
Updated the shiny app:
- merged the gscore object (before, it was separated, one for web input and another for bed file input)
- added 2 new inputs: Organism and Category, for selecting annotation packages
- created a new "Run" button
- added a new "tryCatch" for the bed-file gscore object