### PR TITLE
Shiny app

### DIFF
--- a/inst/shinyApp/global.R
+++ b/inst/shinyApp/global.R
@@ -1,9 +1,9 @@
 # Global options, make DT::rendertable print NA values as 'NA'
 options(htmlwidgets.TOJSON_ARGS = list(na = 'string'))
 
-options <- availableGScores()
+options <- GenomicScores::availableGScores()
 
-AnnotationHub::setAnnotationHubOption("MAX_DOWNLOADS", 100)
+AnnotationHub::setAnnotationHubOption("MAX_DOWNLOADS", 600)
 
 ##### General functions #######
 
@@ -107,6 +107,7 @@ is_within_range <- function(granges, phast){
 # packages previously installed in user's machine. Uses as parameters the
 # package name and its type (GScore is hardcoded in server.R)
 .loadAnnotationPackageObject <- function(pkgName) {
+  
   annotObj <- NULL
   
   if(options[row.names(options)==pkgName,"Installed"]){
@@ -123,9 +124,12 @@ is_within_range <- function(granges, phast){
 }
 
 .installAnnotPkg <-  function(pkgName){
+  
   if(options[row.names(options)==pkgName,"BiocManagerInstall"]){
     BiocManager::install(pkgName, update=FALSE)
   } else {
     getGScores(pkgName)
   }
+  
+  options <<- GenomicScores::availableGScores()
 }

--- a/inst/shinyApp/global.R
+++ b/inst/shinyApp/global.R
@@ -1,11 +1,16 @@
 # Global options, make DT::rendertable print NA values as 'NA'
 options(htmlwidgets.TOJSON_ARGS = list(na = 'string'))
 
+# Global variable that stores the database from availableGscores()
 options <- GenomicScores::availableGScores()
 
+# Global Options for annotationHub: this way, user will not be prompted
+# to confirm downloads or to create the .cache folder
 AnnotationHub::setAnnotationHubOption("MAX_DOWNLOADS", 600)
+AnnotationHub::setAnnotationHubOption("ASk", FALSE)
 
-##### General functions #######
+
+############### GENERAL FUNCTIONS #################
 
 ## imports BED files uploaded by the user through
 ## the shiny app. it only reads the first three

--- a/inst/shinyApp/global.R
+++ b/inst/shinyApp/global.R
@@ -71,7 +71,6 @@ downloadFile <- function(dt, type){
 }
 
 
-
 # Validates if a Shiny input is in fact an integer number
 not_empty_or_char <- function(input){
   if(is.na(suppressWarnings(as.numeric(input)))){

--- a/inst/shinyApp/global.R
+++ b/inst/shinyApp/global.R
@@ -2,7 +2,7 @@
 options(htmlwidgets.TOJSON_ARGS = list(na = 'string'))
 
 # Global variable that stores the database from availableGscores()
-options <- GenomicScores::availableGScores()
+options <- availableGScores()
 
 # Global Options for annotationHub: this way, user will not be prompted
 # to confirm downloads or to create the .cache folder
@@ -135,5 +135,5 @@ is_within_range <- function(granges, phast){
     getGScores(pkgName)
   }
   
-  options <<- GenomicScores::availableGScores()
+  options <<- availableGScores()
 }

--- a/inst/shinyApp/server.R
+++ b/inst/shinyApp/server.R
@@ -203,18 +203,18 @@ server <- function(input, output, session) {
              tryCatch({
                
                switch(input$indOrRange,
-                      individual = GenomicScores::gscores(annot.pkg, 
+                      individual = gscores(annot.pkg, 
                                                           GRanges(seqnames=seqnames(granges), 
                                                                   IRanges(start(granges):end(granges),
                                                                           width=1)),
                                                           pop = population),
-                      range = GenomicScores::gscores(annot.pkg, granges, pop = population))
+                      range = gscores(annot.pkg, granges, pop = population))
                }, error = function(err) return(NULL))},
            
            bed = {
              req(uploadedBed())
              tryCatch({
-               GenomicScores::gscores(annot.pkg, uploadedBed(), pop = population)
+               gscores(annot.pkg, uploadedBed(), pop = population)
                }, error=function(err){
                  stop(print(paste("There seems to be a problem with the bed file\n", err)))
                  return(NULL)})

--- a/inst/shinyApp/server.R
+++ b/inst/shinyApp/server.R
@@ -1,5 +1,150 @@
 server <- function(input, output, session) {
+  
+  ################## UI HIDE AND SHOW  ##################
+  
+  # change inputs for 'web' or 'bed' options
+  observe({
+    if(input$webOrBed == 'web'){
+      shinyjs::showElement("webOptions")
+      shinyjs::hideElement("upload")
+    } else {
+      shinyjs::hideElement("webOptions")
+      shinyjs::showElement("upload")
+    }
+  })
+  
+  # deactivate 'run' button until there is any input in 
+  # input$granges and input$annotPackage
+  observe({
+    if(isTruthy(input$granges) && isTruthy(input$annotPackage) ){
+      shinyjs::enable("run")
+    } else {
+      shinyjs::disable("run")
+    }
+  })
 
+
+  ################## GENERATE INPUTS  ######################## 
+  
+  # Input for annotation pkgs, it's updated with choices in 
+  # 'Organism' and 'Category' selectInput
+  
+  output$apkg <- renderUI({
+    organism <- input$organism
+    category <- input$category
+    options <- if(organism=="All") options else options[which(options$Organism==organism),]
+    options <- if(category=="All") options else options[which(options$Category==category),]
+    tags$div(id="cssref", 
+        selectInput("annotPackage", "Select an Annotation Package",
+                choices = c("Choose a package" = "", row.names(options))))
+  })
+  
+  # this section generates the necessary css style in order to
+  # programmatically change the annot.pkgs colors
+  
+  output$css.apkgs <- renderUI({
+    req(options)
+    names <- row.names(options)
+    tags$style(
+      HTML(unlist(
+        lapply(names, function(x){
+          if(options[row.names(options)==x,]$Installed || options[row.names(options)==x,]$Cached) {
+            sprintf(
+              "#cssref .selectize-dropdown-content > .option[data-value='%s']
+              { color: green; font-weight: bold; }", x)
+          } else {
+            sprintf(
+            "#cssref .selectize-dropdown-content > .option[data-value='%s']
+            { color: red; font-weight: bold; }", x)
+          }
+        })
+      )
+      )
+    )
+  })
+
+  # Observer for input$annotPackage: if user clicks a red option, a new
+  # modal window appears that let's the user install the annot.pkg
+  
+  observeEvent(input$annotPackage, {
+    name <- input$annotPackage
+    if(!name=="" && !(options[row.names(options)==name,]$Installed ||
+                      options[row.names(options)==name,]$Cached))
+      {      
+      showModal(
+        modalDialog(
+          title = "Annotation Packages",
+          div(id="install.text", "The annotation package you chose is not installed and cannot be used yet.
+          Would you like to install it?"),
+          div(p("\n")),
+          verbatimTextOutput("install.progress"),
+          div(id="install.finished"),
+          footer = tagList(
+            actionButton("install.apkgs", "OK"),
+            shinyjs::hidden(actionButton("refresh", "Refresh")),
+            modalButton("Quit")
+          )
+        )
+      )
+    }
+  })
+  
+  # Observer for the 'Ok' button in modal: this will call the .installAnnotPkg fun
+  # that will install the pkg or query it in AnnotHub()
+  observeEvent(input$install.apkgs, {
+    shinyjs::hideElement("install.apkgs")
+    withCallingHandlers({
+      shinyjs::html(id = "install.text", html = paste("
+        <p>Installation of <b>", input$annotPackage, "</b> in progress.<p>
+        <p>This may take a while.</p>
+        <p>You can check the progress on your R console.</p>"))
+      .installAnnotPkg(input$annotPackage)
+      shinyjs::html(id = "install.finished", html = "</br><p>Installation Finished</p>", add = TRUE)
+      shinyjs::html(id = "install.finished", html = "<p>Please take note: in order to use a new annotation package, 
+                      you must refresh this session</p>", add = TRUE)
+    },
+    message = function(m) {
+      shinyjs::html(id = "install.progress", html = m$message, add = TRUE)},
+    warning = function(m) {
+      shinyjs::html(id = "install.progress", html = m$message, add = TRUE)},
+    error = function(m) {
+      shinyjs::html(id = "install.progress", html = m$message, add = TRUE)})
+    shinyjs::show("refresh")
+    })
+  
+  
+  observeEvent(input$refresh, {
+    removeModal()
+    shinyjs::runjs("{history.go(0)}")
+  })
+  
+
+  
+  #### render web parameters and choose between range or individual
+  output$webOptions <- renderUI({
+    req(input$webOrBed=="web")
+    tagList(
+      textInput("granges", "Genomic Range", placeholder = "chr22:50967020-50967025"),
+      radioButtons("indOrRange", "Output type",
+                   choices = list("Genomic range" = "range", "Individual positions" = "individual"))
+    )
+  })
+  
+  ### render selectinput with population options
+  output$pop <- renderUI({
+    req(annotPackage())
+    selectInput("populations", "Select an available population", multiple = TRUE,
+                choices = populations(annotPackage()))
+  })
+  
+  ### render download buttons
+  output$down_btn <- renderUI({
+    req(gsObject)
+    fluidRow(
+             downloadButton("dwn_bed", "Download BED"),
+             downloadButton("dwn_csv", "Download CSV")
+             )
+  })
   
   ################# REACTIVE CORE VALUES #######################
   
@@ -31,7 +176,7 @@ server <- function(input, output, session) {
       population <- defaultPopulation(annot.pkg)
     } else {
       population <- input$populations
-      }
+    }
     
     switch(input$webOrBed,
            web ={
@@ -41,11 +186,11 @@ server <- function(input, output, session) {
              
              tryCatch({
                switch(input$indOrRange,
-                      individual = gscores(annot.pkg, 
-                                           GRanges(seqnames=seqnames(granges), 
-                                                   IRanges(start(granges):end(granges), width=1)),
-                                           pop = population),
-                      range = gscores(annot.pkg, granges, pop = population)
+                      individual = GenomicScores::gscores(annot.pkg, 
+                                                          GRanges(seqnames=seqnames(granges), 
+                                                                  IRanges(start(granges):end(granges), width=1)),
+                                                          pop = population),
+                      range = GenomicScores::gscores(annot.pkg, granges, pop = population)
                )
              }, error = function(err) {
                return(NULL)
@@ -54,152 +199,15 @@ server <- function(input, output, session) {
            bed = {
              req(uploadedBed())
              tryCatch({
-               gscores(annot.pkg, uploadedBed(), pop = population)
+               GenomicScores::gscores(annot.pkg, uploadedBed(), pop = population)
              }, error=function(err){
                stop(print(paste("There seems to be a problem with the bed file\n", err)))
                return(NULL)
-               }
+             }
              )
            })
     
     
-  })
-  
-  
-  ################## UI HIDE AND SHOW  ##################
-  
-  observe({
-    if(input$webOrBed == 'web'){
-      shinyjs::showElement("webOptions")
-      shinyjs::hideElement("upload")
-    } else {
-      shinyjs::hideElement("webOptions")
-      shinyjs::showElement("upload")
-    }
-  })
-  
-  observe({
-    if(isTruthy(input$granges)){
-      shinyjs::enable("run")
-    } else {
-      shinyjs::disable("run")
-    }
-  })
-
-
-  ################## GENERATE INPUTS  ######################## 
-  
-
-  output$apkg <- renderUI({
-    organism <- input$organism
-    category <- input$category
-    options <- if(organism=="All") options else options[which(options$Organism==organism),]
-    options <- if(category=="All") options else options[which(options$Category==category),]
-    tags$div(id="cssref", 
-        selectInput("annotPackage", "Select an Annotation Package",
-                choices = c("Choose a package" = "", row.names(options))))
-  })
-  
-  # this section generates the necessary css style in order to
-  # programmatically change the selectInput() choices' colors
-  
-  output$css.apkgs <- renderUI({
-    req(options)
-    options <- availableGScores()
-    names <- row.names(options)
-    tags$style(
-      HTML(unlist(
-        lapply(names, function(x){
-          if(options[row.names(options)==x,]$Installed || options[row.names(options)==x,]$Cached) {
-            sprintf(
-              "#cssref .selectize-dropdown-content > .option[data-value='%s']
-              { color: green; font-weight: bold; }", x)
-          } else {
-            sprintf(
-            "#cssref .selectize-dropdown-content > .option[data-value='%s']
-            { color: red; font-weight: bold; }", x)
-          }
-        })
-      )
-      )
-    )
-  })
-
-  observeEvent(input$annotPackage, {
-    name <- input$annotPackage
-    if(!name=="" && !(options[row.names(options)==name,]$Installed ||
-                      options[row.names(options)==name,]$Cached))
-      {      
-      showModal(
-        modalDialog(
-          title = "Annotation Packages",
-          div(id="install.text", "The annotation package you chose is not installed and cannot be used yet.
-          Would you like to install it?"),
-          div(p("\n")),
-          verbatimTextOutput("install.progress"),
-          div(id="install.finished"),
-          footer = tagList(
-            actionButton("install.apkgs", "OK"),
-            shinyjs::hidden(actionButton("refresh", "Refresh")),
-            modalButton("Quit")
-          )
-        )
-      )
-    }
-  })
-  
-  observeEvent(input$install.apkgs, {
-    shinyjs::hideElement("install.apkgs")
-      withCallingHandlers({
-        shinyjs::html(id = "install.text", html = paste("
-        <p>Installation of <b>", input$annotPackage, "</b> in progress.<p>
-        <p>This may take a while.</p>
-        <p>You can check the progress on your R console.</p>"))
-        .installAnnotPkg(input$annotPackage)
-        shinyjs::html(id = "install.finished", html = "</br><p>Installation Finished</p>", add = TRUE)
-        shinyjs::html(id = "install.finished", html = "<p>Please take note: in order to use a new annotation package, 
-                      you must refresh this session</p>", add = TRUE)
-        },
-        message = function(m) {
-          shinyjs::html(id = "install.progress", html = m$message, add = TRUE)},
-        warning = function(m) {
-          shinyjs::html(id = "install.progress", html = m$message, add = TRUE)},
-        error = function(m) {
-          shinyjs::html(id = "install.progress", html = m$message, add = TRUE)})
-    shinyjs::show("refresh")
-    })
-  
-  observeEvent(input$refresh, {
-    removeModal()
-    shinyjs::runjs("{history.go(0)}")
-  })
-  
-
-  
-  #### render web parameters and choose between range or individual
-  output$webOptions <- renderUI({
-    req(input$webOrBed=="web")
-    tagList(
-      textInput("granges", "Genomic Range", value = "chr22:50967020-50967025"),
-      radioButtons("indOrRange", "Output type",
-                   choices = list("Genomic range" = "range", "Individual positions" = "individual"))
-    )
-  })
-  
-  ### render selectinput with population options
-  output$pop <- renderUI({
-    req(annotPackage())
-    selectInput("populations", "Select an available population", multiple = TRUE,
-                choices = populations(annotPackage()))
-  })
-  
-  ### render download buttons
-  output$down_btn <- renderUI({
-    req(gsObject)
-    fluidRow(
-             downloadButton("dwn_bed", "Download BED"),
-             downloadButton("dwn_csv", "Download CSV")
-             )
   })
   
   

--- a/inst/shinyApp/server.R
+++ b/inst/shinyApp/server.R
@@ -82,7 +82,8 @@ server <- function(input, output, session) {
           footer = tagList(
             actionButton("install.apkgs", "OK"),
             shinyjs::hidden(actionButton("refresh", "Refresh")),
-            modalButton("Quit")
+            span(id="cancel", modalButton("Cancel")),
+            shinyjs::showElement("cancel")
           )
         )
       )
@@ -109,6 +110,7 @@ server <- function(input, output, session) {
       shinyjs::html(id = "install.progress", html = m$message, add = TRUE)},
     error = function(m) {
       shinyjs::html(id = "install.progress", html = m$message, add = TRUE)})
+    shinyjs::hideElement("cancel")
     shinyjs::show("refresh")
     })
   
@@ -124,7 +126,7 @@ server <- function(input, output, session) {
   output$webOptions <- renderUI({
     req(input$webOrBed=="web")
     tagList(
-      textInput("granges", "Genomic Range", placeholder = "chr22:50967020-50967025"),
+      textInput("granges", "Genomic Range", placeholder = "chromosome:initial-final"),
       radioButtons("indOrRange", "Output type",
                    choices = list("Genomic range" = "range", "Individual positions" = "individual"))
     )


### PR DESCRIPTION
Creates new functionalities in the shinyApp:
- able to filter annot pkg by Organism and Category
- new input for GRanges coordinates
- new functionality for annot pkgs: selectInput colours pkgs if they are installed or in caché, green if ok, red if not.
When user clicks on a red name, a new modal window appears that let the user install from BioConductor or from AnnotationHub
- new "run" button